### PR TITLE
fixes in case answer is json

### DIFF
--- a/lib/proxy-generator.js
+++ b/lib/proxy-generator.js
@@ -8,9 +8,7 @@ var generator = {};
 
 generator.createProxy = function(template, answers, callback){
     var templateAbsolutePath = path.resolve(template);
-    var answersAbsolutePath = path.resolve(answers);
     console.log("Template Location: "+ templateAbsolutePath);
-
 
     var answersData = null;
     templatePath = path.normalize(template);
@@ -18,9 +16,10 @@ generator.createProxy = function(template, answers, callback){
     // support input from file or direct JSON string
     if(fs.existsSync(answers)){
         answersData = fs.readFileSync(answers, 'utf8');
+        var answersAbsolutePath = path.resolve(answers);
         console.log("Answers Location: "+ answersAbsolutePath);
     }else{
-        answersData = answers;
+        answersData = JSON.stringify(answers);
         console.log("Answers not provided as file.  Assuming direct JSON input.");
     }
     readDir(templatePath, function(err, files){


### PR DESCRIPTION
- path.resolve(answers) only if it is a valid path. no need to resolve in case of JSON object.
- since answers can be accepted as JSON object, do stringify() before further processing where it expects as a string (due to readfile)
